### PR TITLE
Add trailer option (when available)

### DIFF
--- a/plugin.video.kodipopcorntime/resources/lib/kodipopcorntime/gui/base3.py
+++ b/plugin.video.kodipopcorntime/resources/lib/kodipopcorntime/gui/base3.py
@@ -27,6 +27,10 @@ class _Base3(_Base2):
         if not isFolder:
             item["context_menu"] = []
             log("(base3-context-menu) %s" %item, LOGLEVEL.INFO)
+
+            if "info" in item and "trailer" in item["info"] and item["info"]["trailer"]:
+                item["context_menu"] = [('%s' %("Trailer"), 'PlayMedia(%s)' %(item["info"]["trailer"]))]
+
             for _q in QUALITIES:
                 if "&%s=" %_q in path or "?%s=" %_q in path:
                     log("(base3-context) %s" %_q, LOGLEVEL.INFO)


### PR DESCRIPTION
### Feature Overview:

#### Problem
- Movie trailer option missing
#### Solution
- Add trailer option to movie quality dialog (when available)

## Tests:
__Movie Trailer:__
- [x] Go to Movies. Right click on a movie with trailer. Click on Trailer option. Confirm it works
- [x] Go to Movies. Right click on a movie _without_ trailer. Confirm the dialog contains only quality options and settings
- [x] Go to TV-Shows. Right click on an episode. Confirm the dialog contains only quality options and settings