### PR TITLE
add trailer string localization

### DIFF
--- a/plugin.video.kodipopcorntime/resources/language/English/strings.xml
+++ b/plugin.video.kodipopcorntime/resources/language/English/strings.xml
@@ -41,6 +41,7 @@
   <string id="30035">New title:</string>
   <string id="30036">Waiting</string>
   <string id="30037">Checking data</string>
+  <string id="30038">Trailer</string>
 
   <!--
    * Settings

--- a/plugin.video.kodipopcorntime/resources/lib/kodipopcorntime/gui/base3.py
+++ b/plugin.video.kodipopcorntime/resources/lib/kodipopcorntime/gui/base3.py
@@ -29,7 +29,7 @@ class _Base3(_Base2):
             log("(base3-context-menu) %s" %item, LOGLEVEL.INFO)
 
             if "info" in item and "trailer" in item["info"] and item["info"]["trailer"]:
-                item["context_menu"] = [('%s' %("Trailer"), 'PlayMedia(%s)' %(item["info"]["trailer"]))]
+                item["context_menu"] = [('%s' %(__addon__.getLocalizedString(30038)), 'PlayMedia(%s)' %(item["info"]["trailer"]))]
 
             for _q in QUALITIES:
                 if "&%s=" %_q in path or "?%s=" %_q in path:


### PR DESCRIPTION
### Issue Overview:

It adds the string localization for the trailer option

## Tests:

__Trailer Option:__
- [x] Open the context menu on a Movie with trailer. Confirm the proper string is used.
