### PR TITLE
Re-enable notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .DS_Store
 Thumbs.db
 ehthumbs.db
+.idea/
+*.pyo

--- a/plugin.video.kodipopcorntime/resources/lib/kodipopcorntime/utils.py
+++ b/plugin.video.kodipopcorntime/resources/lib/kodipopcorntime/utils.py
@@ -2,7 +2,7 @@
 import xbmcgui, xbmc, simplejson, sys, time, os, UserDict, socket, glob
 from urllib import urlencode
 from kodipopcorntime.exceptions import Error
-from kodipopcorntime.logging import log, log_error
+from kodipopcorntime.logging import log, log_error, LOGLEVEL
 from kodipopcorntime import settings
 from kodipopcorntime.threads import FLock
 
@@ -24,8 +24,10 @@ def notify(messageID=0, message=None, level=NOTIFYLEVEL.INFO):
     if not message:
         message = __addon__.getLocalizedString(messageID)
 
-    xbmc.executebuiltin('XBMC.Notification("%s", "%s", "%s", "%s")' %
-                        (settings.addon.name, message, len(message)*210, image))
+    try:
+        xbmc.executebuiltin('XBMC.Notification("%s", "%s", "%s", "%s")' % (settings.addon.name, message, len(message)*210, image))
+    except Exception as e:
+        log('(Utils) Notification failed: %s' % (str(e)), LOGLEVEL.ERROR)
 
 def xbmcItem(label='', label2='', icon=None, thumbnail=None, path=None, info=None,
              info_type='video', properties=None, stream_info=None,

--- a/plugin.video.kodipopcorntime/resources/lib/kodipopcorntime/utils.py
+++ b/plugin.video.kodipopcorntime/resources/lib/kodipopcorntime/utils.py
@@ -24,7 +24,8 @@ def notify(messageID=0, message=None, level=NOTIFYLEVEL.INFO):
     if not message:
         message = __addon__.getLocalizedString(messageID)
 
-    #xbmc.executebuiltin('XBMC.Notification("%s", "%s", "%s", "%s")' %(settings.addon.name, message, len(message)*210, image))
+    xbmc.executebuiltin('XBMC.Notification("%s", "%s", "%s", "%s")' %
+                        (settings.addon.name, message, len(message)*210, image))
 
 def xbmcItem(label='', label2='', icon=None, thumbnail=None, path=None, info=None,
              info_type='video', properties=None, stream_info=None,


### PR DESCRIPTION
I believe the best approach is not to silence notifications, like errors.
Instead, errors should be dealt with accordingly.